### PR TITLE
Save tabs state on 'beforeunload', store currentTabId in localstorage

### DIFF
--- a/packages/components/src/components/editor.tsx
+++ b/packages/components/src/components/editor.tsx
@@ -108,6 +108,25 @@ export const Editor = () => {
   }, [editorView, previousTabId, currentTabId, currentTab, setTabs])
 
   useEffect(() => {
+    const onBeforeUnload = () => {
+      if (!editorView) return
+
+      setTabs((tabs) => {
+        const newTabs = [...tabs]
+        const currentTabIndex = newTabs.findIndex(tab => tab.id === currentTabId)
+        newTabs[currentTabIndex] = { ...newTabs[currentTabIndex], doc: editorView.state.doc.toString() }
+
+        return newTabs
+      })
+      setEditorView(null)
+    }
+
+    window.addEventListener('beforeunload', onBeforeUnload)
+
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [editorView, setTabs, currentTabId])
+
+  useEffect(() => {
     if (!editorView || !currentTab) return
 
     editorView.dispatch({

--- a/packages/components/src/components/tab/types.ts
+++ b/packages/components/src/components/tab/types.ts
@@ -9,4 +9,5 @@ export type Headers = Record<string, string>
 export interface GlobalState {
   tabs: Tab[]
   headers: Headers
+  currentTabId: string
 }


### PR DESCRIPTION
fixes #18 
Store tabs state correctly by calling `setTabs` on the `beforeunload` window event, storing the `currentTabId`  inside localstorage.