### PR TITLE
fix fastify.d.ts export type

### DIFF
--- a/packages/trpc-playground/handlers/fastify.d.ts
+++ b/packages/trpc-playground/handlers/fastify.d.ts
@@ -1,1 +1,1 @@
-export * from '../dist/handlers/fetch'
+export * from '../dist/handlers/fastify'


### PR DESCRIPTION
The fastify adapter incorrectly exports the fetch adapter typescript type. This corrects the export path typing to use the fastify handler.