### PR TITLE
add `https:` protocol to `cdnUrl` default config

### DIFF
--- a/packages/trpc-playground/src/config.ts
+++ b/packages/trpc-playground/src/config.ts
@@ -13,7 +13,7 @@ const getDefaultConfig = () =>
       interval: 4000,
     },
     renderOptions: {
-      cdnUrl: '//cdn.jsdelivr.net/npm',
+      cdnUrl: 'https://cdn.jsdelivr.net/npm',
       version,
     },
     request: {

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -50,7 +50,7 @@ export type RenderOptions = {
   version?: string | null
   /**
    * The cdn to import the @trpc-playground/html scripts from.
-   * @default //cdn.jsdelivr.net/npm
+   * @default https://cdn.jsdelivr.net/npm
    */
   cdnUrl?: string
 }


### PR DESCRIPTION
Safari throws a CORS fit without the `https:` protocol included in the default cdn url and won't load the playground. Other browsers seem fine.

Here is the error in the Safari console:

> Cross-origin redirection to https://cdn.jsdelivr.net/npm/@trpc-playground/html@1.0.0-next.0/dist/assets/index.70ae6946.js denied by Cross-Origin Resource Sharing policy: Origin http://localhost:4000 is not allowed by Access-Control-Allow-Origin. Status code: 302

When I override the default render options the problem on Safari goes away:
```
renderOptions: {
   cdnUrl: 'https://cdn.jsdelivr.net/npm'
}
```

I'm not sure if there is a downside you were trying to avoid by omitting the protocol, so there might be a tradeoff I'm not aware of by doing this.
