### PR TITLE
Fix fastify export

### DIFF
--- a/packages/trpc-playground/handlers/fastify.d.ts
+++ b/packages/trpc-playground/handlers/fastify.d.ts
@@ -1,1 +1,1 @@
-export * from '../dist/handlers/fetch'
+export * from '../dist/handlers/fastify'


### PR DESCRIPTION
Fastify was improperly exporting the fetch handler.